### PR TITLE
Loosened mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"css-loader": "0.5.x",
 		"style-loader": "0.5.x",
 		"loader-utils": "0.2.x",
-		"mocha": "1.7.x"
+		"mocha": "1.x"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
Since mocha has left the development status a long time ago, I think it's safe to loosen the version number. The current version is `1.11.0`.
