### PR TITLE
Add support for mocha-phantomjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports.pitch = function(req) {
 		source.push("require(" + JSON.stringify("!!" + path.join(__dirname, "web.js")) + ");");
 		source.push("mocha.setup(" + JSON.stringify(query["interface"] || "bdd") + ");");
 		source.push("require(" + JSON.stringify("!!" + req) + ")");
-		source.push("mocha.run();");
+		source.push("window.mochaPhantomJS ? mochaPhantomJS.run() : mocha.run();");
 		source.push("if(module.hot) {");
 		source.push("\tmodule.hot.accept();");
 		source.push("\tmodule.hot.dispose(function() {");


### PR DESCRIPTION
This tiny patch adds support for running headless tests via [mocha-phantomjs](https://github.com/metaskills/mocha-phantomjs)
