### PR TITLE
chore(package): add `mocha: ^4.0.0` as a `peerDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/webpack/mocha-loader"
   },
   "peerDependencies": {
-    "mocha": "^2.0.1 || ^3.0.0"
+    "mocha": "^2.0.1 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "script-loader": "~0.7.0",


### PR DESCRIPTION
Resolves https://github.com/webpack-contrib/mocha-loader/issues/66.