### PR TITLE
fix: regression in mocha initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,13 +27,13 @@ export function pitch(req) {
 
   const source = [];
   if (this.target === 'web' || this.target === 'electron-renderer') {
-    source.push(`import ${JSON.stringify(`!!${webScriptPath}`)};`);
+    source.push(`require(${JSON.stringify(`!!${webScriptPath}`)});`);
     source.push(
       "if(typeof window !== 'undefined' && window.initMochaPhantomJS) { window.initMochaPhantomJS(); }"
     );
     source.push(`mocha.setup(${JSON.stringify(options)});`);
-    source.push(`import ${JSON.stringify(`!!${req}`)}`);
-    source.push(`import ${JSON.stringify(`!!${startScriptPath}`)};`);
+    source.push(`require(${JSON.stringify(`!!${req}`)});`);
+    source.push(`require(${JSON.stringify(`!!${startScriptPath}`)});`);
     source.push('if(module.hot) {');
     source.push('\tmodule.hot.accept();');
     source.push('\tmodule.hot.dispose(function() {');


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
imports got hoisted by webpack, causing the `mocha.setup(options)` call to happen after evaluation of the test files, which broke because `describe` wasn't defined yet.
This reverts the change of `require()` calls to `import`s (for browser init).
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
None.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
Tested locally against a real project. Major can probably be released post this fix.