### PR TITLE
fix: remove archived script-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10207,11 +10207,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "raw-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -10692,14 +10687,6 @@
       "requires": {
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1"
-      }
-    },
-    "script-loader": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
-      "integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
-      "requires": {
-        "raw-loader": "~0.5.1"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "css-loader": "^3.4.1",
     "loader-utils": "^1.2.3",
     "schema-utils": "^2.6.1",
-    "script-loader": "^0.7.2",
     "style-loader": "^1.1.2"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export function pitch(req) {
     source.push(
       `require(${stringify(`!!style-loader!css-loader!${mochaCss}`)});`
     );
-    source.push(`require(${stringify(`!!script-loader!${mochaJs}`)});`);
+    source.push(`require(${stringify(`!!${mochaJs}`)});`);
     source.push(`mocha.setup(${stringify(options)});`);
     source.push(`require(${stringify(`!!${req}`)});`);
     source.push(`require(${stringify(`!!${startScriptPath}`)});`);


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Using `script-loader` is not really needed with today's mocha/webpack versions. Requiring `mocha.js` directly sets up globals properly.
Has the effect of removing old (indirect) `raw-loader` as well.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

None.

### Additional Info
